### PR TITLE
perf: Adjust copychars to use `slice` instead of `substr`

### DIFF
--- a/src/copychars.js
+++ b/src/copychars.js
@@ -14,5 +14,7 @@ export default function copychars(string, start = 0, length) {
     return "";
   }
 
-  return (" " + string.substr(start, length)).substr(1);
+  const end = Number.isInteger(length) ? start + length : undefined;
+
+  return (" " + string.slice(start, end)).slice(1);
 }


### PR DESCRIPTION
Change `copychars` to use `String.prototype.slice()` instead of `String.prototype.substr()`  to copy chars as the latter uses significantly more memory.

Please note that  `substr `  is also not considered a part of the core ECMAScript language and its usage is not recommended.

https://www.ecma-international.org/ecma-262/6.0/#sec-string.prototype.substr

Closes DCOS-38362